### PR TITLE
Add SHA.js

### DIFF
--- a/bench-hash.js
+++ b/bench-hash.js
@@ -1,15 +1,20 @@
-
 var args = process.argv.slice(2)
 var lib = args.shift() || 'crypto-browserify'
 var alg = args.shift() || 'sha1'
 var randomData = require('crypto').pseudoRandomBytes
-var Buffer = require('buffer').Buffer
 
 //generate 10 megs of random data
 var M = 10*1000*1000
 var data = randomData(M)
 
 var libs = {
+  'sha.js': function(alg) {
+    var sha = require('sha.js')
+    return function (data) {
+      return (new (sha[alg])()).update(data).digest('hex')
+    }
+  },
+
   'crypto-browserify': function (alg) {
     var createHash = require('crypto-browserify').createHash
     return function (data) {
@@ -44,7 +49,7 @@ var libs = {
   jshashes: function (alg) {
     var jshashes = require('jshashes')
     if (alg == 'ripemd160') alg = 'RMD160'
-      
+
     var Hash = jshashes[alg.toUpperCase()]
     var hash = new Hash()
     return function (data) {
@@ -52,9 +57,9 @@ var libs = {
     }
   },
   cryptomx: function (alg) {
-    if(!/^(sha256|ripemd)$/.test(alg))  
+    if(!/^(sha256|ripemd)$/.test(alg))
       throw new Error('algorithm '+alg+' is not implemented by cryptomx library')
-    return function (data) {      
+    return function (data) {
       return require('cryptomx')[alg](data.toString('binary'))
     }
   },
@@ -80,17 +85,14 @@ var libs = {
     return function (data) {
       return sha1.digestFromBuffer(data)
     }
-
-
   }
-
 }
 
 var prev = 0
 var hash = libs[lib](alg)
 
-//for(var i = 79; i <= 80; i++) {
-  console.log('run (N), input-size (bytes), ops (bytes/ms), time (ms)')
+console.log('run (N), input-size (bytes), ops (bytes/ms), time (ms)')
+
 var i = 1
 
 ;(function loop () {
@@ -111,4 +113,3 @@ var i = 1
   i++
   setTimeout(loop, 10)
 })()
-//}

--- a/package.json
+++ b/package.json
@@ -8,17 +8,18 @@
     "url": "git://github.com/dominictarr/crypto-bench.git"
   },
   "dependencies": {
-    "crypto-js": "~3.1.2-2",
-    "node-forge": "~0.2.23",
-    "sjcl": "https://github.com/dominictarr/sjcl/archive/built.tar.gz",
-    "crypto-browserify": "~2.1.0",
     "blake2s": "~1.0.0",
-    "ripemd160": "~0.1.0",
-    "jshashes": "~1.0.4",
+    "crypto-browserify": "~2.1.0",
+    "crypto-js": "~3.1.2-2",
     "cryptomx": "~1.0.1",
-    "rusha": "~0.7.2",
+    "git-sha1": "~0.1.0",
     "js-nacl": "~0.5.0",
-    "git-sha1": "~0.1.0"
+    "jshashes": "~1.0.4",
+    "node-forge": "~0.2.23",
+    "ripemd160": "~0.1.0",
+    "rusha": "~0.7.2",
+    "sha.js": "^2.3.1",
+    "sjcl": "https://github.com/dominictarr/sjcl/archive/built.tar.gz"
   },
   "devDependencies": {
     "himark": "~1.0.4",


### PR DESCRIPTION
This pull request adds sha.js for comparison.
Technically covered by crypto-browserify, but allows for a more direct comparison in the event crypto-browserify changes implementation (or perhaps, is not in sync with the latest version).